### PR TITLE
fix(emqttb): fix default intervals

### DIFF
--- a/grafana/dashboards/emqttb-dashboard.json
+++ b/grafana/dashboards/emqttb-dashboard.json
@@ -184,7 +184,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(emqttb_group_n_workers{}[5s])",
+          "expr": "rate(emqttb_group_n_workers{}[30s])",
           "interval": "",
           "legendFormat": "{{group}}",
           "refId": "A"
@@ -266,7 +266,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(emqttb_published_messages{}[5s])",
+          "expr": "rate(emqttb_published_messages{}[30s])",
           "interval": "",
           "legendFormat": "{{group}}",
           "refId": "A"
@@ -348,7 +348,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(emqttb_received_messages{}[5s])",
+          "expr": "rate(emqttb_received_messages{}[30s])",
           "interval": "",
           "legendFormat": "{{group}}",
           "refId": "A"


### PR DESCRIPTION
Since, currently, the scrape interval in CDK is 15 s, we need a larger interval for rates to return data.